### PR TITLE
Fix typo in array storage talk calendar event

### DIFF
--- a/welcome.ipynb
+++ b/welcome.ipynb
@@ -141,7 +141,7 @@
     "\n",
     "- March 12: \"pytest\" by Josh Karpel\n",
     "\n",
-    "- April 9: \"HDF + NetCFD + Zarr for array storage in Python\" by David Hoese and James Bourbeau\n",
+    "- April 9: \"HDF5 + NetCDF4 + Zarr for array storage in Python\" by David Hoese and James Bourbeau\n",
     "\n",
     "- May 14: \"Continuously deploying a python application with Gitlab CI/CD and Terraform\" by Pierce Edmiston"
    ]


### PR DESCRIPTION
Noticed this at the last meeting ("NetCFD" -> "NetCDF"). Also thought I'd add the version numbers since the 5 in HDF5 and 4 in NetCDF4 are important when comparing them to older versions of the formats.